### PR TITLE
feat(tron-chess): add 3d neon board

### DIFF
--- a/games/tron-chess/.eslintrc.cjs
+++ b/games/tron-chess/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+  ignorePatterns: ['dist', 'node_modules'],
+};

--- a/games/tron-chess/.prettierrc
+++ b/games/tron-chess/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": true
+}

--- a/games/tron-chess/package-lock.json
+++ b/games/tron-chess/package-lock.json
@@ -1,0 +1,936 @@
+{
+  "name": "tron-chess",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tron-chess",
+      "version": "0.1.0",
+      "dependencies": {
+        "chess.js": "^1.0.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.4.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
+      "integrity": "sha512-Zj3Hl6sN34xJtMv7Anwb5Gu01yujyE/cLBDB2gnHTAHaWS1Z38L7kuSG+oAh0giZMqG060f/YBStXtMH6FvPMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.46.2.tgz",
+      "integrity": "sha512-nTeCWY83kN64oQ5MGz3CgtPx8NSOhC5lWtsjTs+8JAJNLcP3QbLCtDDgUKQc/Ro/frpMq4SHUaHN6AMltcEoLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.46.2.tgz",
+      "integrity": "sha512-HV7bW2Fb/F5KPdM/9bApunQh68YVDU8sO8BvcW9OngQVN3HHHkw99wFupuUJfGR9pYLLAjcAOA6iO+evsbBaPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.46.2.tgz",
+      "integrity": "sha512-SSj8TlYV5nJixSsm/y3QXfhspSiLYP11zpfwp6G/YDXctf3Xkdnk4woJIF5VQe0of2OjzTt8EsxnJDCdHd2xMA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.46.2.tgz",
+      "integrity": "sha512-ZyrsG4TIT9xnOlLsSSi9w/X29tCbK1yegE49RYm3tu3wF1L/B6LVMqnEWyDB26d9Ecx9zrmXCiPmIabVuLmNSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.46.2.tgz",
+      "integrity": "sha512-pCgHFoOECwVCJ5GFq8+gR8SBKnMO+xe5UEqbemxBpCKYQddRQMgomv1104RnLSg7nNvgKy05sLsY51+OVRyiVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.46.2.tgz",
+      "integrity": "sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.46.2.tgz",
+      "integrity": "sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.46.2.tgz",
+      "integrity": "sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.46.2.tgz",
+      "integrity": "sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.46.2.tgz",
+      "integrity": "sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.46.2.tgz",
+      "integrity": "sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.46.2.tgz",
+      "integrity": "sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.46.2.tgz",
+      "integrity": "sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.46.2.tgz",
+      "integrity": "sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.46.2.tgz",
+      "integrity": "sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.46.2.tgz",
+      "integrity": "sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.46.2.tgz",
+      "integrity": "sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.46.2.tgz",
+      "integrity": "sha512-gBgaUDESVzMgWZhcyjfs9QFK16D8K6QZpwAaVNJxYDLHWayOta4ZMjGm/vsAEy3hvlS2GosVFlBlP9/Wb85DqQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.46.2.tgz",
+      "integrity": "sha512-CvUo2ixeIQGtF6WvuB87XWqPQkoFAFqW+HUo/WzHwuHDvIwZCtjdWXoYCcr06iKGydiqTclC4jU/TNObC/xKZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.46.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
+      "integrity": "sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.46.2",
+        "@rollup/rollup-android-arm64": "4.46.2",
+        "@rollup/rollup-darwin-arm64": "4.46.2",
+        "@rollup/rollup-darwin-x64": "4.46.2",
+        "@rollup/rollup-freebsd-arm64": "4.46.2",
+        "@rollup/rollup-freebsd-x64": "4.46.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.46.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.46.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.46.2",
+        "@rollup/rollup-linux-arm64-musl": "4.46.2",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.46.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.46.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.46.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-gnu": "4.46.2",
+        "@rollup/rollup-linux-x64-musl": "4.46.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.46.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.46.2",
+        "@rollup/rollup-win32-x64-msvc": "4.46.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
+      "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/games/tron-chess/package.json
+++ b/games/tron-chess/package.json
@@ -6,14 +6,22 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview --port 5174"
+    "preview": "vite preview --port 5174",
+    "lint": "eslint src tests --ext .ts",
+    "fmt": "prettier src tests --write",
+    "test": "vitest run"
   },
   "dependencies": {
     "chess.js": "^1.0.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.56.0",
+    "prettier": "^3.0.0",
     "typescript": "^5.4.0",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0"
   }
 }
 

--- a/games/tron-chess/src/main.ts
+++ b/games/tron-chess/src/main.ts
@@ -1,6 +1,7 @@
 import { Chess } from 'chess.js';
 
-type Square = `${'a'|'b'|'c'|'d'|'e'|'f'|'g'|'h'}${1|2|3|4|5|6|7|8}`;
+type Square =
+  `${'a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h'}${1 | 2 | 3 | 4 | 5 | 6 | 7 | 8}`;
 
 const APP = document.getElementById('app')!;
 
@@ -8,32 +9,49 @@ const APP = document.getElementById('app')!;
 class Sound {
   private ctx: AudioContext | null = null;
   private ensure() {
-    if (!this.ctx) this.ctx = new (window.AudioContext || (window as any).webkitAudioContext)();
+    if (!this.ctx)
+      this.ctx = new (window.AudioContext ||
+        (window as any).webkitAudioContext)();
   }
   play(freq: number, dur = 0.08, type: OscillatorType = 'sine', gain = 0.06) {
     this.ensure();
     const ctx = this.ctx!;
     const o = ctx.createOscillator();
     const g = ctx.createGain();
-    o.frequency.value = freq; o.type = type;
+    o.frequency.value = freq;
+    o.type = type;
     g.gain.value = gain;
     o.connect(g).connect(ctx.destination);
     o.start();
     o.stop(ctx.currentTime + dur);
   }
-  move() { this.play(660, 0.08, 'triangle', 0.05); }
-  capture() { this.play(330, 0.12, 'square', 0.06); }
-  check() { this.play(880, 0.18, 'sawtooth', 0.05); }
+  move() {
+    this.play(660, 0.08, 'triangle', 0.05);
+  }
+  capture() {
+    this.play(330, 0.12, 'square', 0.06);
+  }
+  check() {
+    this.play(880, 0.18, 'sawtooth', 0.05);
+  }
 }
 const SND = new Sound();
 
 // App state
-let mode: 'hvh'|'hva' = 'hvh';
+let mode: 'hvh' | 'hva' = 'hvh';
 let aiDepth = 2;
 
 // Game state
 const chess = new Chess();
-let orientation: 'w'|'b' = 'w';
+let orientation: 'w' | 'b' = 'w';
+
+/**
+ * Calculate the board rotation for a 3D display. White faces "0deg" while
+ * black flips the board 180 degrees around the Z axis.
+ */
+export function boardRotation(o: 'w' | 'b'): string {
+  return o === 'w' ? '0deg' : '180deg';
+}
 let selected: Square | null = null;
 let legal: Set<Square> = new Set();
 const history: string[] = [];
@@ -61,21 +79,34 @@ function renderMenu() {
       </div>
     </div>
   `;
-  document.getElementById('m-hvh')!.addEventListener('click', () => { mode='hvh'; startGame(); });
-  document.getElementById('m-hva')!.addEventListener('click', () => { mode='hva'; const d=(document.getElementById('depth') as HTMLSelectElement).value; aiDepth = parseInt(d,10); startGame(); });
+  document.getElementById('m-hvh')!.addEventListener('click', () => {
+    mode = 'hvh';
+    startGame();
+  });
+  document.getElementById('m-hva')!.addEventListener('click', () => {
+    mode = 'hva';
+    const d = (document.getElementById('depth') as HTMLSelectElement).value;
+    aiDepth = parseInt(d, 10);
+    startGame();
+  });
 }
 
-function startGame(){
-  chess.reset(); selected=null; legal.clear(); history.length=0; lastFrom=lastTo=null; orientation='w';
+function startGame() {
+  chess.reset();
+  selected = null;
+  legal.clear();
+  history.length = 0;
+  lastFrom = lastTo = null;
+  orientation = 'w';
   renderGameUI();
 }
 
-function renderGameUI(){
+function renderGameUI() {
   APP.innerHTML = `
   <div class="container">
     <div class="header">
       <div class="title">TRON CHESS</div>
-      <span class="badge">${mode==='hvh'?'Local 2P':'AI Depth '+aiDepth}</span>
+      <span class="badge">${mode === 'hvh' ? 'Local 2P' : 'AI Depth ' + aiDepth}</span>
     </div>
     <div class="board-wrap">
       <div class="board" id="board"></div>
@@ -92,14 +123,36 @@ function renderGameUI(){
       </div>
     </div>
   </div>`;
-  document.getElementById('new')!.addEventListener('click', () => { chess.reset(); selected=null; legal.clear(); history.length=0; lastFrom=lastTo=null; render(); });
-  document.getElementById('flip')!.addEventListener('click', () => { orientation = orientation==='w'?'b':'w'; render(); });
-  document.getElementById('undo')!.addEventListener('click', () => { if(thinking) return; chess.undo(); history.pop(); selected=null; legal.clear(); lastFrom=lastTo=null; render(); });
-  document.getElementById('menu')!.addEventListener('click', () => renderMenu());
+  document.getElementById('new')!.addEventListener('click', () => {
+    chess.reset();
+    selected = null;
+    legal.clear();
+    history.length = 0;
+    lastFrom = lastTo = null;
+    render();
+  });
+  document.getElementById('flip')!.addEventListener('click', () => {
+    orientation = orientation === 'w' ? 'b' : 'w';
+    render();
+  });
+  document.getElementById('undo')!.addEventListener('click', () => {
+    if (thinking) return;
+    chess.undo();
+    history.pop();
+    selected = null;
+    legal.clear();
+    lastFrom = lastTo = null;
+    render();
+  });
+  document
+    .getElementById('menu')!
+    .addEventListener('click', () => renderMenu());
   render();
 }
 
-function squareAt(file:number, rank:number): Square { return (String.fromCharCode('a'.charCodeAt(0)+file) + (rank+1)) as Square; }
+function squareAt(file: number, rank: number): Square {
+  return (String.fromCharCode('a'.charCodeAt(0) + file) + (rank + 1)) as Square;
+}
 
 function render() {
   const boardEl = document.getElementById('board')!;
@@ -107,21 +160,23 @@ function render() {
   const movesEl = document.getElementById('moves')!;
   boardEl.classList.toggle('check', chess.in_check());
   boardEl.innerHTML = '';
+  boardEl.style.setProperty('--rot', boardRotation(orientation));
   const grid = document.createElement('div');
   grid.className = 'grid';
   const files = [...Array(8).keys()];
   const ranks = [...Array(8).keys()];
-  const rf = orientation==='w' ? ranks.slice().reverse() : ranks;
-  const ff = orientation==='w' ? files : files.slice().reverse();
+  const rf = orientation === 'w' ? ranks.slice().reverse() : ranks;
+  const ff = orientation === 'w' ? files : files.slice().reverse();
   for (const r of rf) {
     for (const f of ff) {
       const sq = squareAt(f, r);
       const piece = chess.get(sq as any);
       const light = (r + f) % 2 === 0;
       const cell = document.createElement('div');
-      const movedFrom = lastFrom===sq ? 'move-from' : '';
-      const movedTo = lastTo===sq ? 'move-to' : '';
-      cell.className = `square ${light?'light':'dark'} ${selected===sq?'selected':''} ${movedFrom} ${movedTo}`.trim();
+      const movedFrom = lastFrom === sq ? 'move-from' : '';
+      const movedTo = lastTo === sq ? 'move-to' : '';
+      cell.className =
+        `square ${light ? 'light' : 'dark'} ${selected === sq ? 'selected' : ''} ${movedFrom} ${movedTo}`.trim();
       cell.dataset.square = sq;
       cell.addEventListener('click', () => onSquareClick(sq));
       if (legal.has(sq)) {
@@ -131,7 +186,7 @@ function render() {
       }
       if (piece) {
         const span = document.createElement('span');
-        span.className = `piece ${piece.color==='b'?'black':'white'}`;
+        span.className = `piece ${piece.color === 'b' ? 'black' : 'white'}`;
         span.textContent = glyph(piece.type, piece.color);
         cell.appendChild(span);
       }
@@ -140,19 +195,26 @@ function render() {
   }
   boardEl.appendChild(grid);
   updateStatus(statusEl, movesEl);
-  if (mode==='hva' && chess.turn()==='b') maybeAITurn();
+  if (mode === 'hva' && chess.turn() === 'b') maybeAITurn();
 }
 
 function onSquareClick(sq: Square) {
   if (thinking) return;
   const piece = chess.get(sq as any);
   if (selected) {
-    const mv = chess.move({ from: selected as any, to: sq as any, promotion: 'q' });
+    const mv = chess.move({
+      from: selected as any,
+      to: sq as any,
+      promotion: 'q',
+    });
     if (mv) {
       history.push(mv.san);
-      lastFrom = mv.from as Square; lastTo = mv.to as Square;
-      selected = null; legal.clear();
-      if (mv.captured) SND.capture(); else SND.move();
+      lastFrom = mv.from as Square;
+      lastTo = mv.to as Square;
+      selected = null;
+      legal.clear();
+      if (mv.captured) SND.capture();
+      else SND.move();
       if (chess.in_check()) SND.check();
       render();
       return;
@@ -160,85 +222,133 @@ function onSquareClick(sq: Square) {
   }
   if (piece && piece.color === chess.turn()) {
     selected = sq;
-    legal = new Set(chess.moves({ square: sq as any, verbose: true }).map((m:any)=>m.to));
-  } else { selected = null; legal.clear(); }
+    legal = new Set(
+      chess.moves({ square: sq as any, verbose: true }).map((m: any) => m.to),
+    );
+  } else {
+    selected = null;
+    legal.clear();
+  }
   render();
 }
 
-function glyph(type:string, color:'w'|'b'){
-  const map: Record<string, [string,string]> = { k:['♔','♚'], q:['♕','♛'], r:['♖','♜'], b:['♗','♝'], n:['♘','♞'], p:['♙','♟'] };
-  const [w,b] = map[type];
-  return color==='w'?w:b;
+function glyph(type: string, color: 'w' | 'b') {
+  const map: Record<string, [string, string]> = {
+    k: ['♔', '♚'],
+    q: ['♕', '♛'],
+    r: ['♖', '♜'],
+    b: ['♗', '♝'],
+    n: ['♘', '♞'],
+    p: ['♙', '♟'],
+  };
+  const [w, b] = map[type];
+  return color === 'w' ? w : b;
 }
 
-function updateStatus(statusEl:HTMLElement, movesEl:HTMLElement){
-  const turn = chess.turn()==='w'?'White':'Black';
+function updateStatus(statusEl: HTMLElement, movesEl: HTMLElement) {
+  const turn = chess.turn() === 'w' ? 'White' : 'Black';
   const inCheck = chess.in_check();
   const over = chess.isGameOver();
   const checkmate = chess.isCheckmate();
   const draw = chess.isDraw();
   statusEl.innerHTML = `
-    <div><strong>Turn:</strong> <span class="badge">${turn}${thinking?' • AI thinking…':''}</span> ${inCheck?'<span class="badge" style="border-color:#ff5c86aa;color:#ff7da4">Check</span>':''}</div>
-    <div><strong>State:</strong> ${over ? (checkmate?'<span class="badge" style="border-color:#ff5c86aa;color:#ff7da4">Checkmate</span>': draw?'<span class="badge">Draw</span>':'Over') : '<span class="badge">Playing</span>'}</div>
+    <div><strong>Turn:</strong> <span class="badge">${turn}${thinking ? ' • AI thinking…' : ''}</span> ${inCheck ? '<span class="badge" style="border-color:#ff5c86aa;color:#ff7da4">Check</span>' : ''}</div>
+    <div><strong>State:</strong> ${over ? (checkmate ? '<span class="badge" style="border-color:#ff5c86aa;color:#ff7da4">Checkmate</span>' : draw ? '<span class="badge">Draw</span>' : 'Over') : '<span class="badge">Playing</span>'}</div>
   `;
-  movesEl.innerHTML = history.map((san,i)=>`<div class="move">${i+1}. ${san}</div>`).join('');
+  movesEl.innerHTML = history
+    .map((san, i) => `<div class="move">${i + 1}. ${san}</div>`)
+    .join('');
 }
 
 // Basic minimax AI with alpha-beta and material eval
-function evaluateBoard(ch: Chess): number {
-  const pvals: Record<string, number> = { p:100, n:320, b:330, r:500, q:900, k:20000 };
+export function evaluateBoard(ch: Chess): number {
+  const pvals: Record<string, number> = {
+    p: 100,
+    n: 320,
+    b: 330,
+    r: 500,
+    q: 900,
+    k: 20000,
+  };
   let score = 0;
-  for (const sq of ['a','b','c','d','e','f','g','h'] as const) {
-    for (let r=1;r<=8;r++) {
-      const p = ch.get((sq+String(r)) as any);
+  for (const sq of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] as const) {
+    for (let r = 1; r <= 8; r++) {
+      const p = ch.get((sq + String(r)) as any);
       if (!p) continue;
       const v = pvals[p.type];
-      score += p.color==='w' ? v : -v;
+      score += p.color === 'w' ? v : -v;
     }
   }
   return score;
 }
 
-function minimaxRoot(depth:number, ch:Chess, isMax:boolean) {
-  const moves:any[] = ch.moves({ verbose: true });
-  let bestMove:any = null;
+function minimaxRoot(depth: number, ch: Chess, isMax: boolean) {
+  const moves: any[] = ch.moves({ verbose: true });
+  let bestMove: any = null;
   let bestVal = isMax ? -Infinity : Infinity;
   for (const m of moves) {
     ch.move(m);
-    const val = minimax(depth-1, ch, -Infinity, Infinity, !isMax);
+    const val = minimax(depth - 1, ch, -Infinity, Infinity, !isMax);
     ch.undo();
-    if (isMax && val > bestVal) { bestVal = val; bestMove = m; }
-    if (!isMax && val < bestVal) { bestVal = val; bestMove = m; }
+    if (isMax && val > bestVal) {
+      bestVal = val;
+      bestMove = m;
+    }
+    if (!isMax && val < bestVal) {
+      bestVal = val;
+      bestMove = m;
+    }
   }
   return bestMove;
 }
 
-function minimax(depth:number, ch:Chess, alpha:number, beta:number, maximizing:boolean): number {
-  if (depth===0 || ch.isGameOver()) return evaluateBoard(ch);
-  const moves:any[] = ch.moves({ verbose: true });
+function minimax(
+  depth: number,
+  ch: Chess,
+  alpha: number,
+  beta: number,
+  maximizing: boolean,
+): number {
+  if (depth === 0 || ch.isGameOver()) return evaluateBoard(ch);
+  const moves: any[] = ch.moves({ verbose: true });
   if (maximizing) {
     let best = -Infinity;
-    for (const m of moves) { ch.move(m); best = Math.max(best, minimax(depth-1, ch, alpha, beta, false)); ch.undo(); alpha = Math.max(alpha, best); if (beta <= alpha) break; }
+    for (const m of moves) {
+      ch.move(m);
+      best = Math.max(best, minimax(depth - 1, ch, alpha, beta, false));
+      ch.undo();
+      alpha = Math.max(alpha, best);
+      if (beta <= alpha) break;
+    }
     return best;
   } else {
     let best = Infinity;
-    for (const m of moves) { ch.move(m); best = Math.min(best, minimax(depth-1, ch, alpha, beta, true)); ch.undo(); beta = Math.min(beta, best); if (beta <= alpha) break; }
+    for (const m of moves) {
+      ch.move(m);
+      best = Math.min(best, minimax(depth - 1, ch, alpha, beta, true));
+      ch.undo();
+      beta = Math.min(beta, best);
+      if (beta <= alpha) break;
+    }
     return best;
   }
 }
 
-function maybeAITurn(){
-  if (mode!=='hva') return;
-  if (chess.turn()!=='b') return;
-  thinking = true; render();
+function maybeAITurn() {
+  if (mode !== 'hva') return;
+  if (chess.turn() !== 'b') return;
+  thinking = true;
+  render();
   setTimeout(() => {
     const best = minimaxRoot(aiDepth, chess, false);
     if (best) {
       const mv = chess.move(best);
       if (mv) {
         history.push(mv.san);
-        lastFrom = mv.from as Square; lastTo = mv.to as Square;
-        if (mv.captured) SND.capture(); else SND.move();
+        lastFrom = mv.from as Square;
+        lastTo = mv.to as Square;
+        if (mv.captured) SND.capture();
+        else SND.move();
         if (chess.in_check()) SND.check();
       }
     }

--- a/games/tron-chess/src/styles.css
+++ b/games/tron-chess/src/styles.css
@@ -11,17 +11,65 @@
   --danger: #ff3b6b;
 }
 
-* { box-sizing: border-box; }
-html, body, #app { height: 100%; }
-body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; color: var(--text); background: radial-gradient(1200px 800px at -10% -20%, #00e5ff11, transparent), radial-gradient(900px 600px at 110% 10%, #7a5cff11, transparent), linear-gradient(180deg, #05070e, #0a0f22); }
+* {
+  box-sizing: border-box;
+}
+html,
+body,
+#app {
+  height: 100%;
+}
+body {
+  margin: 0;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial;
+  color: var(--text);
+  background:
+    radial-gradient(1200px 800px at -10% -20%, #00e5ff11, transparent),
+    radial-gradient(900px 600px at 110% 10%, #7a5cff11, transparent),
+    linear-gradient(180deg, #05070e, #0a0f22);
+}
 
-.container { max-width: 1100px; margin: 0 auto; padding: 24px; }
-.header { display: flex; align-items: center; gap: 16px; padding: 12px 0; }
-.title { font-weight: 800; letter-spacing: 0.6px; }
-.badge { display:inline-block; padding: 4px 10px; border-radius:999px; border:1px solid var(--panel-border); color: var(--accent); }
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
+.header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+.title {
+  font-weight: 800;
+  letter-spacing: 0.6px;
+}
+.badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--panel-border);
+  color: var(--accent);
+}
 
-.board-wrap { display: grid; grid-template-columns: 1fr 320px; gap: 18px; align-items: start; }
-@media (max-width: 980px) { .board-wrap { grid-template-columns: 1fr; } }
+.board-wrap {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 18px;
+  align-items: start;
+}
+@media (max-width: 980px) {
+  .board-wrap {
+    grid-template-columns: 1fr;
+  }
+}
 
 .board {
   position: relative;
@@ -31,47 +79,232 @@ body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI
   background: linear-gradient(180deg, #061221c9, #081433c9);
   box-shadow: 0 20px 60px #0008;
   overflow: hidden;
+  perspective: 1000px;
 }
 
 .board.check {
   animation: board-pulse 0.8s ease-out 1;
-  box-shadow: 0 0 30px #ff3b6bcc, 0 20px 60px #0008;
+  box-shadow:
+    0 0 30px #ff3b6bcc,
+    0 20px 60px #0008;
 }
-@keyframes board-pulse { 0% { box-shadow: 0 0 0 #ff3b6b00, 0 20px 60px #0008; } 50% { box-shadow: 0 0 40px #ff3b6bcc, 0 20px 60px #0008; } 100% { box-shadow: 0 0 0 #ff3b6b00, 0 20px 60px #0008; } }
+@keyframes board-pulse {
+  0% {
+    box-shadow:
+      0 0 0 #ff3b6b00,
+      0 20px 60px #0008;
+  }
+  50% {
+    box-shadow:
+      0 0 40px #ff3b6bcc,
+      0 20px 60px #0008;
+  }
+  100% {
+    box-shadow:
+      0 0 0 #ff3b6b00,
+      0 20px 60px #0008;
+  }
+}
 
 .grid {
-  position: absolute; inset: 0; display: grid; grid-template-columns: repeat(8, 1fr); grid-template-rows: repeat(8, 1fr);
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  transform-style: preserve-3d;
+  transform: rotateX(60deg) rotateZ(var(--rot, 0deg));
+  transition: transform 0.4s ease;
 }
-.square { position: relative; display: flex; align-items: center; justify-content: center; cursor: pointer; user-select: none; }
-.square::before { content: ''; position: absolute; inset: 0; border: 1px solid transparent; }
-.square.dark::before { border-color: var(--grid-2); box-shadow: inset 0 0 14px #08f3; }
-.square.light::before { border-color: var(--grid); box-shadow: inset 0 0 14px #0ff3; }
-.square:hover::before { box-shadow: inset 0 0 18px #0ff6, 0 0 10px #0ff3; }
+.square {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  user-select: none;
+  transform-style: preserve-3d;
+}
+.square::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+}
+.square.dark::before {
+  border-color: var(--grid-2);
+  box-shadow: inset 0 0 14px #08f3;
+}
+.square.light::before {
+  border-color: var(--grid);
+  box-shadow: inset 0 0 14px #0ff3;
+}
+.square:hover::before {
+  box-shadow:
+    inset 0 0 18px #0ff6,
+    0 0 10px #0ff3;
+}
 
-.move-from::after { content:''; position:absolute; inset:4px; border-radius: 10px; box-shadow: 0 0 22px #00e5ffaa; border: 2px solid #00e5ff88; animation: glow 1.2s ease-out 1; }
-.move-to::after { content:''; position:absolute; inset:4px; border-radius: 10px; box-shadow: 0 0 22px #7a5cffaa; border: 2px solid #7a5cff88; animation: glow 1.2s ease-out 1; }
-@keyframes glow { 0% { opacity: 0; } 30% { opacity: 1; } 100% { opacity: 0; } }
+.move-from::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 10px;
+  box-shadow: 0 0 22px #00e5ffaa;
+  border: 2px solid #00e5ff88;
+  animation: glow 1.2s ease-out 1;
+}
+.move-to::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 10px;
+  box-shadow: 0 0 22px #7a5cffaa;
+  border: 2px solid #7a5cff88;
+  animation: glow 1.2s ease-out 1;
+}
+@keyframes glow {
+  0% {
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
 
-.piece { font-size: clamp(28px, 6.6vmin, 72px); filter: drop-shadow(0 0 6px #0ff8); text-shadow: 0 0 10px #0ff8, 0 0 22px #0ff4; }
-.piece.black { color: #a6b4ff; filter: drop-shadow(0 0 6px #7a5cff88); text-shadow: 0 0 10px #7a5cffcc, 0 0 22px #7a5cff88; }
+.piece {
+  font-size: clamp(28px, 6.6vmin, 72px);
+  filter: drop-shadow(0 0 6px #0ff8);
+  text-shadow:
+    0 0 10px #0ff8,
+    0 0 22px #0ff4;
+  transform: translateZ(20px);
+}
+.piece.black {
+  color: #a6b4ff;
+  filter: drop-shadow(0 0 6px #7a5cff88);
+  text-shadow:
+    0 0 10px #7a5cffcc,
+    0 0 22px #7a5cff88;
+}
 
-.hint { position: absolute; width: 16px; height: 16px; border-radius: 50%; box-shadow: 0 0 16px #0ff9, inset 0 0 8px #0ff7; background: #0ff4; }
-.capture { position:absolute; inset: 6px; border-radius: 12px; border: 2px dashed #ff5c86aa; box-shadow: 0 0 12px #ff3b6b88; }
-.selected::after { content:''; position:absolute; inset: -2px; border: 2px solid #00e5ffcc; border-radius: 14px; box-shadow: 0 0 18px #00e5ffaa; }
+.hint {
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  box-shadow:
+    0 0 16px #0ff9,
+    inset 0 0 8px #0ff7;
+  background: #0ff4;
+}
+.capture {
+  position: absolute;
+  inset: 6px;
+  border-radius: 12px;
+  border: 2px dashed #ff5c86aa;
+  box-shadow: 0 0 12px #ff3b6b88;
+}
+.selected::after {
+  content: '';
+  position: absolute;
+  inset: -2px;
+  border: 2px solid #00e5ffcc;
+  border-radius: 14px;
+  box-shadow: 0 0 18px #00e5ffaa;
+}
 
-.panel { background: var(--panel); border: 1px solid var(--panel-border); border-radius: 14px; padding: 14px; box-shadow: 0 12px 30px #0006; }
-.controls { display: flex; gap: 10px; flex-wrap: wrap; }
-.btn { appearance: none; background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: white; border: 0; padding: 10px 14px; border-radius: 12px; font-weight: 700; cursor: pointer; box-shadow: 0 8px 22px #00e5ff33; }
-.btn.ghost { background: transparent; color: var(--text); border: 1px solid var(--panel-border); box-shadow: none; }
-.status { display: grid; gap: 8px; }
-.moves { max-height: 280px; overflow: auto; }
-.move { color: var(--muted); }
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 14px;
+  padding: 14px;
+  box-shadow: 0 12px 30px #0006;
+}
+.controls {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.btn {
+  appearance: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: white;
+  border: 0;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 8px 22px #00e5ff33;
+}
+.btn.ghost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--panel-border);
+  box-shadow: none;
+}
+.status {
+  display: grid;
+  gap: 8px;
+}
+.moves {
+  max-height: 280px;
+  overflow: auto;
+}
+.move {
+  color: var(--muted);
+}
 
 /* Splash Menu */
-.splash { display:grid; place-items:center; min-height: 100vh; text-align:center; }
-.logo { font-size: clamp(32px, 8vw, 72px); font-weight: 900; letter-spacing: 2px; color: #00e5ff; text-shadow: 0 0 14px #00e5ffcc, 0 0 40px #00e5ff66; }
-.logo small { display:block; font-size: 16px; color: #a9c4d6; letter-spacing: 4px; margin-top: 6px; }
-.splash-card { margin-top: 22px; max-width: 620px; padding: 22px; border-radius: 18px; background: var(--panel); border: 1px solid var(--panel-border); box-shadow: 0 16px 44px #0008; }
-.mode { display:flex; gap: 12px; justify-content:center; flex-wrap:wrap; margin-top: 10px; }
-.select { background: transparent; color: var(--text); border: 1px solid var(--panel-border); border-radius: 10px; padding: 8px 10px; }
-.hintline { color: var(--muted); margin-top: 10px; }
+.splash {
+  display: grid;
+  place-items: center;
+  min-height: 100vh;
+  text-align: center;
+}
+.logo {
+  font-size: clamp(32px, 8vw, 72px);
+  font-weight: 900;
+  letter-spacing: 2px;
+  color: #00e5ff;
+  text-shadow:
+    0 0 14px #00e5ffcc,
+    0 0 40px #00e5ff66;
+}
+.logo small {
+  display: block;
+  font-size: 16px;
+  color: #a9c4d6;
+  letter-spacing: 4px;
+  margin-top: 6px;
+}
+.splash-card {
+  margin-top: 22px;
+  max-width: 620px;
+  padding: 22px;
+  border-radius: 18px;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  box-shadow: 0 16px 44px #0008;
+}
+.mode {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+.select {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  padding: 8px 10px;
+}
+.hintline {
+  color: var(--muted);
+  margin-top: 10px;
+}

--- a/games/tron-chess/tests/main.test.ts
+++ b/games/tron-chess/tests/main.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { boardRotation, evaluateBoard } from '../src/main';
+import { Chess } from 'chess.js';
+
+describe('boardRotation', () => {
+  it('returns 0deg for white', () => {
+    expect(boardRotation('w')).toBe('0deg');
+  });
+  it('returns 180deg for black', () => {
+    expect(boardRotation('b')).toBe('180deg');
+  });
+});
+
+describe('evaluateBoard', () => {
+  it('is zero for the starting position', () => {
+    const ch = new Chess();
+    expect(evaluateBoard(ch)).toBe(0);
+  });
+  it('decreases when white loses material', () => {
+    const ch = new Chess();
+    ch.remove('a2');
+    expect(evaluateBoard(ch)).toBe(-100);
+  });
+});

--- a/games/tron-chess/tsconfig.json
+++ b/games/tron-chess/tsconfig.json
@@ -9,8 +9,9 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["vitest/globals"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "tests/**/*"]
 }
 


### PR DESCRIPTION
## Summary
- style chess board with 3D perspective and neon pieces
- expose board rotation logic and evaluate board scores
- add linting, formatting, and unit tests

## Testing
- `npm run fmt`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896e200c0388330a18956f10f303a72