### PR TITLE
feat: add agentic pipeline orchestration dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Tron Chess
 
-This repository now contains only the Tron Chess web game built with TypeScript and Vite.
+This repository now contains both the Tron Chess web game and the Agentic Pipelines demo application.
 
 ## Development
+
+### Tron Chess
 
 Install dependencies and start the dev server:
 
@@ -17,3 +19,15 @@ Build for production:
 ```bash
 npm run build
 ```
+
+### Agentic Pipelines Demo
+
+The agentic pipelines product lives in the `apps/agentic-pipelines` workspace. To run it locally:
+
+```bash
+cd apps/agentic-pipelines
+npm install
+npm run dev
+```
+
+This will start a Vite development server. Follow the terminal output to open the provided local URL (typically `http://localhost:5173`) in your browser and interact with the shadcn UI-driven workflows.

--- a/apps/agentic-pipelines/eslint.config.js
+++ b/apps/agentic-pipelines/eslint.config.js
@@ -1,0 +1,49 @@
+import js from "@eslint/js";
+import pluginReact from "eslint-plugin-react";
+import pluginReactHooks from "eslint-plugin-react-hooks";
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+
+const recommendedTypeScriptRules = tsPlugin.configs.recommended?.rules ?? {};
+const recommendedReactRules = pluginReact.configs.recommended?.rules ?? {};
+const recommendedReactHooksRules = pluginReactHooks.configs.recommended?.rules ?? {};
+
+export default [
+  {
+    ignores: ["dist", "node_modules"]
+  },
+  {
+    files: ["**/*.{ts,tsx}"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      globals: {
+        ...js.configs.recommended.languageOptions?.globals
+      }
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+      react: pluginReact,
+      "react-hooks": pluginReactHooks
+    },
+    settings: {
+      react: {
+        version: "detect"
+      }
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...recommendedTypeScriptRules,
+      ...recommendedReactRules,
+      ...recommendedReactHooksRules,
+      "react/react-in-jsx-scope": "off",
+      "react/prop-types": "off"
+    }
+  }
+];

--- a/apps/agentic-pipelines/index.html
+++ b/apps/agentic-pipelines/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agentic Pipelines</title>
+  </head>
+  <body class="bg-background text-foreground">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/agentic-pipelines/package.json
+++ b/apps/agentic-pipelines/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "agentic-pipelines",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint \"src/**/*.{ts,tsx}\""
+  },
+  "dependencies": {
+    "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-progress": "^1.0.3",
+    "@radix-ui/react-scroll-area": "^1.0.5",
+    "@radix-ui/react-separator": "^1.0.3",
+    "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-tabs": "^1.0.3",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.378.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.3",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.18",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "jsdom": "^24.0.0",
+    "postcss": "^8.4.31",
+    "tailwindcss": "^3.4.1",
+    "tailwindcss-animate": "^1.0.7",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.8",
+    "vitest": "^1.2.0"
+  }
+}

--- a/apps/agentic-pipelines/postcss.config.js
+++ b/apps/agentic-pipelines/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/agentic-pipelines/src/App.test.tsx
+++ b/apps/agentic-pipelines/src/App.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import App from "./App";
+import { vi } from "vitest";
+
+describe("App", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("renders hero content and workflow picker", () => {
+    render(<App />);
+    expect(screen.getByText(/Agentic pipeline orchestrator/i)).toBeInTheDocument();
+    expect(screen.getByText(/Cloud Release Autopilot/i)).toBeInTheDocument();
+  });
+
+  it("allows selecting a different workflow", () => {
+    render(<App />);
+    const buttons = screen.getAllByRole("button", { name: /select workflow/i });
+    fireEvent.click(buttons[0]);
+    expect(screen.getByText(/Secure Supply Chain pipeline/i)).toBeInTheDocument();
+  });
+
+  it("runs the pipeline and completes all steps", async () => {
+    render(<App />);
+    const executeButton = screen.getByRole("button", { name: /execute pipeline/i });
+
+    fireEvent.click(executeButton);
+    expect(screen.getByText(/Pipeline running/i)).toBeInTheDocument();
+
+    await act(async () => {
+      vi.runAllTimers();
+    });
+
+    const completedBadges = screen.getAllByText(/Completed/i);
+    expect(completedBadges.length).toBeGreaterThanOrEqual(4);
+    expect(screen.getByRole("button", { name: /execute pipeline/i })).toBeEnabled();
+  });
+});

--- a/apps/agentic-pipelines/src/App.tsx
+++ b/apps/agentic-pipelines/src/App.tsx
@@ -1,0 +1,405 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PipelineRunPanel } from "./components/pipeline/pipeline-run-panel";
+import { WorkflowPicker } from "./components/pipeline/workflow-picker";
+import type {
+  PipelineRunState,
+  PipelineStep,
+  StepRunState,
+  Workflow
+} from "./components/pipeline/types";
+import { Badge } from "./components/ui/badge";
+import { Separator } from "./components/ui/separator";
+import { Layers, LineChart, ShieldCheck, Sparkles } from "lucide-react";
+
+const workflows: Workflow[] = [
+  {
+    id: "cloud-release",
+    name: "Cloud Release Autopilot",
+    description:
+      "Progressively deploy services with environment drift detection, gated rollouts, and automated health verification.",
+    category: "DevOps",
+    trigger: "Git push to main / codex-cli deploy --env production",
+    successCriteria: "Blue/green cutover with zero failed health checks across regions",
+    estimatedDurationMinutes: 18,
+    steps: [
+      {
+        id: "plan-release",
+        title: "Compile deployment plan",
+        summary: "Evaluate infrastructure drift, generate deployment manifest, and notify change advisory.",
+        capability: "DevOps",
+        agent: "Atlas DevOps",
+        command: "codex-cli deploy plan --env production --drift-detection",
+        estimatedMinutes: 4,
+        successCriteria: "Change set approved with no critical drift detected"
+      },
+      {
+        id: "security-scan",
+        title: "Enforce release security gates",
+        summary: "Run SBOM diff, secrets scan, and package signature verification before rollout.",
+        capability: "AppSec",
+        agent: "Sentinel AppSec",
+        command: "codex-cli appsec verify --release $GIT_SHA --policy prod",
+        estimatedMinutes: 5,
+        successCriteria: "All policies satisfied; zero critical vulnerabilities"
+      },
+      {
+        id: "progressive-rollout",
+        title: "Execute progressive rollout",
+        summary: "Automate canary, analyze live metrics, and promote traffic across clusters.",
+        capability: "DevOps",
+        agent: "Atlas DevOps",
+        command: "codex-cli deploy rollout --strategy canary --env production",
+        estimatedMinutes: 6,
+        successCriteria: "Canary promoted with SLO error budget intact"
+      },
+      {
+        id: "post-deploy",
+        title: "Post-deploy validation",
+        summary: "Run smoke tests, capture dashboards, and archive deployment transcript.",
+        capability: "DevOps",
+        agent: "Observer QA",
+        command: "codex-cli qa verify --suite smoke --env production",
+        estimatedMinutes: 3,
+        successCriteria: "Synthetic transactions succeed and monitoring baselines restored"
+      }
+    ]
+  },
+  {
+    id: "secure-supply-chain",
+    name: "Secure Supply Chain",
+    description:
+      "Continuously harden the software supply chain with provenance capture, policy enforcement, and runtime attestation.",
+    category: "AppSec",
+    trigger: "Nightly codex-cli compliance run",
+    successCriteria: "Artifacts signed, provenance stored, and runtime baselines updated",
+    estimatedDurationMinutes: 22,
+    steps: [
+      {
+        id: "sbom-generate",
+        title: "Generate and diff SBOM",
+        summary: "Produce software bill of materials, compare to baseline, and flag drift.",
+        capability: "AppSec",
+        agent: "Sentinel AppSec",
+        command: "codex-cli appsec sbom --module api --fail-on drift",
+        estimatedMinutes: 6,
+        successCriteria: "SBOM diff acknowledged with no unvetted components"
+      },
+      {
+        id: "runtime-scan",
+        title: "Runtime sensor sweep",
+        summary: "Scan running workloads for CVEs, misconfigurations, and leaked secrets.",
+        capability: "AppSec",
+        agent: "Guardian Runtime",
+        command: "codex-cli runtime scan --workload api --deep",
+        estimatedMinutes: 5,
+        successCriteria: "No critical runtime findings remain open"
+      },
+      {
+        id: "policy-enforce",
+        title: "Policy enforcement snapshot",
+        summary: "Validate OPA policies, admission controllers, and infrastructure guardrails.",
+        capability: "DevOps",
+        agent: "Atlas DevOps",
+        command: "codex-cli policy evaluate --bundle supply-chain --env prod",
+        estimatedMinutes: 5,
+        successCriteria: "Cluster policies validated with full compliance"
+      },
+      {
+        id: "attestation",
+        title: "Publish attestation",
+        summary: "Sign build outputs, push to provenance ledger, and notify auditors.",
+        capability: "AppSec",
+        agent: "Sentinel AppSec",
+        command: "codex-cli attest release --target api --channel auditors",
+        estimatedMinutes: 6,
+        successCriteria: "Attestation recorded with traceable provenance"
+      }
+    ]
+  },
+  {
+    id: "finops-guardrails",
+    name: "FinOps Guardrails",
+    description:
+      "Monitor spend, forecast burn, and orchestrate remediation actions across multi-cloud workloads.",
+    category: "FinOps",
+    trigger: "Hourly codex-cli cost monitor",
+    successCriteria: "Spend forecasts updated with automated savings actions executed",
+    estimatedDurationMinutes: 16,
+    steps: [
+      {
+        id: "ingest-costs",
+        title: "Ingest live cost feeds",
+        summary: "Pull billing exports, normalize tags, and enrich with usage context.",
+        capability: "FinOps",
+        agent: "Ledger FinOps",
+        command: "codex-cli finops ingest --sources aws,gcp --window 1h",
+        estimatedMinutes: 4,
+        successCriteria: "Unified dataset published with cost anomalies labeled"
+      },
+      {
+        id: "forecast",
+        title: "Forecast burn down",
+        summary: "Apply ML forecast, compute savings opportunities, and flag outliers.",
+        capability: "FinOps",
+        agent: "Ledger FinOps",
+        command: "codex-cli finops forecast --horizon 30d --scenario proactive",
+        estimatedMinutes: 4,
+        successCriteria: "Forecast variance within 3% of historical accuracy"
+      },
+      {
+        id: "optimize",
+        title: "Automate optimization playbooks",
+        summary: "Right-size workloads, schedule idle resources, and push IaC merge requests.",
+        capability: "DevOps",
+        agent: "Atlas DevOps",
+        command: "codex-cli finops optimize --apply --channels sre,owners",
+        estimatedMinutes: 5,
+        successCriteria: "Optimization tasks executed with owner acknowledgement"
+      },
+      {
+        id: "report",
+        title: "Broadcast executive digest",
+        summary: "Publish savings report, update dashboard tiles, and send executive summary.",
+        capability: "FinOps",
+        agent: "Ledger FinOps",
+        command: "codex-cli finops report --audience exec --format pdf",
+        estimatedMinutes: 3,
+        successCriteria: "Stakeholders receive actionable savings digest"
+      }
+    ]
+  }
+];
+
+const PIPELINE_DELAY_FACTOR_MS = 350;
+
+function createIdleRunState(): PipelineRunState {
+  return {
+    status: "idle",
+    steps: [],
+    currentStepIndex: 0
+  };
+}
+
+function createStartLogs(step: PipelineStep): string[] {
+  return [
+    `🚀 Launching ${step.agent} (${step.capability})`,
+    `🔧 Executing command: ${step.command}`,
+    `🎯 Success criteria: ${step.successCriteria}`
+  ];
+}
+
+function createCompletionLogs(step: PipelineStep): string[] {
+  return [
+    `✅ ${step.agent} completed ${step.title}`,
+    `📈 Outcome aligned: ${step.successCriteria}`
+  ];
+}
+
+export default function App() {
+  const [selectedWorkflowId, setSelectedWorkflowId] = useState<string>(workflows[0]?.id ?? "");
+  const [runState, setRunState] = useState<PipelineRunState>(() => createIdleRunState());
+  const timerRef = useRef<number | null>(null);
+
+  const selectedWorkflow = useMemo(
+    () => workflows.find((workflow) => workflow.id === selectedWorkflowId),
+    [selectedWorkflowId]
+  );
+
+  const capabilitySummary = useMemo(() => {
+    return workflows.reduce(
+      (acc, workflow) => {
+        workflow.steps.forEach((step) => {
+          acc[step.capability] = (acc[step.capability] ?? 0) + 1;
+        });
+        return acc;
+      },
+      {} as Record<string, number>
+    );
+  }, []);
+
+  const handleSelectWorkflow = useCallback((workflowId: string) => {
+    if (timerRef.current) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setSelectedWorkflowId(workflowId);
+    setRunState(createIdleRunState());
+  }, []);
+
+  const startPipeline = useCallback(() => {
+    if (!selectedWorkflow) {
+      return;
+    }
+    const now = Date.now();
+    if (selectedWorkflow.steps.length === 0) {
+      setRunState({
+        status: "succeeded",
+        steps: [],
+        currentStepIndex: 0,
+        startedAt: now,
+        completedAt: now
+      });
+      return;
+    }
+
+    setRunState({
+      status: "running",
+      steps: selectedWorkflow.steps.map((step, index) => ({
+        step,
+        status: index === 0 ? "running" : "pending",
+        startedAt: index === 0 ? now : undefined,
+        logs: index === 0 ? createStartLogs(step) : []
+      })),
+      currentStepIndex: 0,
+      startedAt: now
+    });
+  }, [selectedWorkflow]);
+
+  useEffect(() => {
+    if (!selectedWorkflow) {
+      return undefined;
+    }
+    if (runState.status !== "running") {
+      return undefined;
+    }
+    const activeStep = runState.steps[runState.currentStepIndex];
+    if (!activeStep || activeStep.status !== "running") {
+      return undefined;
+    }
+
+    const delay = Math.max(activeStep.step.estimatedMinutes, 1) * PIPELINE_DELAY_FACTOR_MS;
+    timerRef.current = window.setTimeout(() => {
+      setRunState((previous) => {
+        const current = previous.steps[previous.currentStepIndex];
+        if (!current) {
+          return previous;
+        }
+
+        const updatedSteps: StepRunState[] = previous.steps.map((state, index) => {
+          if (index === previous.currentStepIndex) {
+            return {
+              ...state,
+              status: "succeeded",
+              completedAt: Date.now(),
+              logs: [...state.logs, ...createCompletionLogs(state.step)]
+            };
+          }
+          if (index === previous.currentStepIndex + 1) {
+            return {
+              ...state,
+              status: "running",
+              startedAt: Date.now(),
+              logs: [...state.logs, ...createStartLogs(state.step)]
+            };
+          }
+          return state;
+        });
+
+        const nextIndex = previous.currentStepIndex + 1;
+        const isComplete = nextIndex >= updatedSteps.length;
+
+        return {
+          status: isComplete ? "succeeded" : "running",
+          steps: updatedSteps,
+          currentStepIndex: isComplete
+            ? Math.max(updatedSteps.length - 1, 0)
+            : nextIndex,
+          startedAt: previous.startedAt,
+          completedAt: isComplete ? Date.now() : previous.completedAt
+        };
+      });
+    }, delay);
+
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [runState, selectedWorkflow]);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        window.clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  const totalAgents = useMemo(() => {
+    const agentIds = new Set<string>();
+    workflows.forEach((workflow) => {
+      workflow.steps.forEach((step) => agentIds.add(step.agent));
+    });
+    return agentIds.size;
+  }, []);
+
+  const totalSteps = useMemo(() => workflows.reduce((acc, workflow) => acc + workflow.steps.length, 0), []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-background">
+      <header className="border-b bg-background/80 backdrop-blur">
+        <div className="container space-y-8 py-10">
+          <div className="flex flex-wrap items-center gap-3 text-sm font-semibold text-primary">
+            <Sparkles className="h-4 w-4" /> Agentic pipeline orchestrator
+          </div>
+          <div className="grid gap-6 lg:grid-cols-[3fr,2fr] lg:items-center">
+            <div className="space-y-6">
+              <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+                Compose DevOps, AppSec, and FinOps workflows that execute like clockwork
+              </h1>
+              <p className="max-w-2xl text-base text-muted-foreground">
+                Choose a runbook, preview the orchestrated agents, and observe the pipeline as it executes
+                codex-cli and agentic tasks with audit-ready telemetry.
+              </p>
+              <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+                <span className="flex items-center gap-2">
+                  <Layers className="h-4 w-4 text-primary" />
+                  {workflows.length} curated workflows
+                </span>
+                <span className="flex items-center gap-2">
+                  <ShieldCheck className="h-4 w-4 text-primary" />
+                  {totalAgents} dedicated agents
+                </span>
+                <span className="flex items-center gap-2">
+                  <LineChart className="h-4 w-4 text-primary" />
+                  {totalSteps} orchestrated steps
+                </span>
+              </div>
+            </div>
+            <div className="space-y-4 rounded-2xl border bg-card p-6 shadow-sm">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                Capability coverage
+              </h2>
+              <div className="flex flex-wrap gap-3">
+                {Object.entries(capabilitySummary).map(([capability, count]) => (
+                  <Badge key={capability} variant="secondary" className="gap-2 text-sm">
+                    <span className="font-semibold text-foreground">{count}</span> {capability} touchpoints
+                  </Badge>
+                ))}
+              </div>
+            </div>
+          </div>
+          <Separator />
+        </div>
+      </header>
+      <main className="container space-y-12 py-12">
+        <section className="space-y-6">
+          <div className="space-y-1">
+            <h2 className="text-2xl font-semibold text-foreground">Pick a workflow</h2>
+            <p className="text-sm text-muted-foreground">
+              Each runbook orchestrates codex-cli commands and specialised agents to deliver autonomous platform
+              outcomes.
+            </p>
+          </div>
+          <WorkflowPicker
+            workflows={workflows}
+            selectedWorkflowId={selectedWorkflowId}
+            onSelect={handleSelectWorkflow}
+          />
+        </section>
+        <PipelineRunPanel workflow={selectedWorkflow} runState={runState} onStart={startPipeline} />
+      </main>
+    </div>
+  );
+}

--- a/apps/agentic-pipelines/src/components/pipeline/pipeline-run-panel.tsx
+++ b/apps/agentic-pipelines/src/components/pipeline/pipeline-run-panel.tsx
@@ -1,0 +1,279 @@
+import { useMemo } from "react";
+import { Badge } from "../ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "../ui/card";
+import { Button } from "../ui/button";
+import { Progress } from "../ui/progress";
+import { ScrollArea } from "../ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
+import { Separator } from "../ui/separator";
+import type { PipelineRunState, StepRunState, Workflow } from "./types";
+import { cn } from "../../lib/utils";
+import { Clock, GaugeCircle, Sparkles, Wand2 } from "lucide-react";
+
+export interface PipelineRunPanelProps {
+  workflow?: Workflow;
+  runState: PipelineRunState;
+  onStart: () => void;
+}
+export function PipelineRunPanel({ workflow, runState, onStart }: PipelineRunPanelProps) {
+  const totalSteps = workflow?.steps.length ?? 0;
+  const completedSteps = runState.steps.filter((step) => step.status === "succeeded").length;
+  const progressValue = totalSteps === 0 ? 0 : Math.round((completedSteps / totalSteps) * 100);
+  const isRunning = runState.status === "running";
+
+  const uniqueAgents = useMemo(() => {
+    if (!workflow) return [];
+    const map = new Map<string, { capability: string; command: string }>();
+    workflow.steps.forEach((step) => {
+      if (!map.has(step.agent)) {
+        map.set(step.agent, {
+          capability: step.capability,
+          command: step.command
+        });
+      }
+    });
+    return Array.from(map.entries());
+  }, [workflow]);
+
+  if (!workflow) {
+    return (
+      <Card className="border-dashed">
+        <CardHeader>
+          <CardTitle>Select a workflow to inspect the orchestration pipeline</CardTitle>
+          <CardDescription>
+            Pick one of the workflows above to preview the execution graph, agent roster, and
+            observability signals for the run.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+  return (
+    <Card className="shadow-lg">
+      <CardHeader className="gap-4 space-y-4 sm:space-y-0 sm:[&>div]:flex sm:[&>div]:justify-between">
+        <div className="space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant="secondary" className="uppercase tracking-wide">
+              {workflow.category}
+            </Badge>
+            <Badge className="bg-primary/15 text-primary">{totalSteps} orchestrated steps</Badge>
+            <Badge variant="secondary" className="gap-1">
+              <GaugeCircle className="h-3 w-3" />
+              SLA {workflow.estimatedDurationMinutes}m
+            </Badge>
+          </div>
+          <CardTitle className="text-3xl font-bold">{workflow.name} pipeline</CardTitle>
+          <CardDescription>{workflow.description}</CardDescription>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button onClick={onStart} disabled={isRunning} size="lg">
+            {isRunning ? "Pipeline running" : "Execute pipeline"}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-8">
+        <section className="space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="space-y-1">
+              <p className="text-sm font-medium text-muted-foreground">Run progress</p>
+              <p className="text-2xl font-semibold text-foreground">{progressValue}%</p>
+            </div>
+            <div className="flex gap-6 text-sm text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Sparkles className="h-4 w-4 text-primary" />
+                <span>{completedSteps} completed</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4 text-primary" />
+                <span>{workflow.estimatedDurationMinutes}m target</span>
+              </div>
+            </div>
+          </div>
+          <Progress value={progressValue} />
+        </section>
+        <Tabs defaultValue="steps" className="space-y-4">
+          <TabsList className="w-full sm:w-auto">
+            <TabsTrigger className="flex-1 sm:flex-none" value="steps">
+              Execution feed
+            </TabsTrigger>
+            <TabsTrigger className="flex-1 sm:flex-none" value="agents">
+              Agent roster
+            </TabsTrigger>
+            <TabsTrigger className="flex-1 sm:flex-none" value="insights">
+              Run insights
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="steps" className="border-none p-0 outline-none">
+            <ScrollArea className="h-[360px] rounded-lg border bg-card">
+              <div className="divide-y">
+                {runState.steps.map((stepState) => (
+                  <StepItem key={stepState.step.id} stepState={stepState} />
+                ))}
+                {runState.steps.length === 0 ? (
+                  <div className="p-6 text-sm text-muted-foreground">
+                    Pipeline ready. Kick off an execution to stream orchestration events.
+                  </div>
+                ) : null}
+              </div>
+            </ScrollArea>
+          </TabsContent>
+
+          <TabsContent value="agents" className="border-none p-0 outline-none">
+            <div className="grid gap-4 md:grid-cols-2">
+              {uniqueAgents.map(([agent, meta]) => (
+                <Card key={agent} className="border border-dashed">
+                  <CardHeader className="space-y-2">
+                    <Badge variant="secondary" className="w-fit uppercase tracking-wide">
+                      {meta.capability}
+                    </Badge>
+                    <CardTitle className="text-xl">{agent}</CardTitle>
+                    <CardDescription className="font-mono text-xs">
+                      {meta.command}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="text-sm text-muted-foreground">
+                    Purpose: orchestrates {meta.capability} objectives for this workflow.
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="insights" className="border-none p-0 outline-none">
+            <div className="grid gap-4 md:grid-cols-2">
+              <InsightCard
+                title="Current status"
+                description={
+                  runState.status === "idle"
+                    ? "No active run"
+                    : runState.status === "running"
+                    ? "Pipeline execution in progress"
+                    : "Pipeline completed successfully"
+                }
+                metric={runState.status.toUpperCase()}
+              />
+              <InsightCard
+                title="Steps remaining"
+                description="Tasks left before the pipeline finalizes"
+                metric={`${Math.max(totalSteps - completedSteps, 0)}`}
+              />
+              <InsightCard
+                title="Average step duration"
+                description="Based on the runbook expectations"
+                metric={`${Math.round(
+                  workflow.steps.reduce((acc, step) => acc + step.estimatedMinutes, 0) /
+                    (workflow.steps.length || 1)
+                )}m`}
+              />
+              <InsightCard
+                title="Success criteria"
+                description={workflow.successCriteria}
+                metric="Aligned"
+              />
+            </div>
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}
+interface StepItemProps {
+  stepState: StepRunState;
+}
+
+function StepItem({ stepState }: StepItemProps) {
+  const statusBadge = (() => {
+    switch (stepState.status) {
+      case "running":
+        return <Badge className="bg-primary/15 text-primary">Running</Badge>;
+      case "succeeded":
+        return <Badge className="bg-emerald-500/15 text-emerald-600">Completed</Badge>;
+      case "pending":
+        return <Badge variant="secondary">Pending</Badge>;
+      default:
+        return <Badge variant="secondary">Idle</Badge>;
+    }
+  })();
+
+  const timelineColor = (() => {
+    switch (stepState.status) {
+      case "running":
+        return "bg-primary";
+      case "succeeded":
+        return "bg-emerald-500";
+      case "pending":
+        return "bg-muted";
+      default:
+        return "bg-muted";
+    }
+  })();
+
+  return (
+    <div className="flex items-start gap-4 p-6">
+      <div className="flex flex-col items-center gap-6">
+        <div className={cn("h-3 w-3 rounded-full ring-4 ring-background", timelineColor)} />
+      </div>
+      <div className="flex-1 space-y-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <p className="text-base font-semibold text-foreground">{stepState.step.title}</p>
+            <p className="text-sm text-muted-foreground">{stepState.step.summary}</p>
+          </div>
+          <div className="flex flex-col items-start gap-2 sm:items-end">
+            {statusBadge}
+            <Badge variant="secondary" className="uppercase tracking-wide">
+              {stepState.step.capability}
+            </Badge>
+          </div>
+        </div>
+        <div className="grid gap-2 text-xs text-muted-foreground md:grid-cols-2">
+          <div>
+            <p className="font-medium text-foreground">Agent</p>
+            <p>{stepState.step.agent}</p>
+          </div>
+          <div>
+            <p className="font-medium text-foreground">Command</p>
+            <p className="font-mono text-xs">{stepState.step.command}</p>
+          </div>
+        </div>
+        {stepState.logs.length ? (
+          <div className="space-y-1 rounded-lg border bg-muted/40 p-3 text-xs text-muted-foreground">
+            {stepState.logs.slice(-3).map((log, logIndex) => (
+              <p key={logIndex}>{log}</p>
+            ))}
+          </div>
+        ) : null}
+        <Separator />
+      </div>
+    </div>
+  );
+}
+interface InsightCardProps {
+  title: string;
+  description: string;
+  metric: string;
+}
+
+function InsightCard({ title, description, metric }: InsightCardProps) {
+  return (
+    <Card className="border border-dashed">
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Wand2 className="h-4 w-4 text-primary" />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-3xl font-semibold text-foreground">{metric}</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/agentic-pipelines/src/components/pipeline/types.ts
+++ b/apps/agentic-pipelines/src/components/pipeline/types.ts
@@ -1,0 +1,41 @@
+export type Capability = "DevOps" | "AppSec" | "FinOps";
+
+export interface PipelineStep {
+  id: string;
+  title: string;
+  summary: string;
+  capability: Capability;
+  agent: string;
+  command: string;
+  estimatedMinutes: number;
+  successCriteria: string;
+}
+
+export interface Workflow {
+  id: string;
+  name: string;
+  description: string;
+  category: Capability;
+  trigger: string;
+  successCriteria: string;
+  estimatedDurationMinutes: number;
+  steps: PipelineStep[];
+}
+
+export type StepStatus = "idle" | "pending" | "running" | "succeeded";
+
+export interface StepRunState {
+  step: PipelineStep;
+  status: StepStatus;
+  startedAt?: number;
+  completedAt?: number;
+  logs: string[];
+}
+
+export interface PipelineRunState {
+  status: "idle" | "running" | "succeeded";
+  steps: StepRunState[];
+  currentStepIndex: number;
+  startedAt?: number;
+  completedAt?: number;
+}

--- a/apps/agentic-pipelines/src/components/pipeline/workflow-picker.tsx
+++ b/apps/agentic-pipelines/src/components/pipeline/workflow-picker.tsx
@@ -1,0 +1,72 @@
+import { Badge } from "../ui/badge";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle
+} from "../ui/card";
+import { Button } from "../ui/button";
+import type { Workflow } from "./types";
+import { cn } from "../../lib/utils";
+import { Check } from "lucide-react";
+
+export interface WorkflowPickerProps {
+  workflows: Workflow[];
+  selectedWorkflowId: string;
+  onSelect: (workflowId: string) => void;
+}
+
+export function WorkflowPicker({ workflows, selectedWorkflowId, onSelect }: WorkflowPickerProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+      {workflows.map((workflow) => {
+        const isActive = workflow.id === selectedWorkflowId;
+        return (
+          <Card
+            key={workflow.id}
+            className={cn(
+              "border-2 transition hover:border-primary/60",
+              isActive ? "border-primary shadow-lg" : "border-transparent"
+            )}
+          >
+            <CardHeader className="space-y-3">
+              <div className="flex items-start justify-between gap-2">
+                <Badge variant={isActive ? "default" : "secondary"}>{workflow.category}</Badge>
+                {isActive ? (
+                  <Badge className="gap-1 bg-primary/15 text-primary">
+                    <Check className="h-3 w-3" /> Active
+                  </Badge>
+                ) : null}
+              </div>
+              <CardTitle>{workflow.name}</CardTitle>
+              <CardDescription>{workflow.description}</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm text-muted-foreground">
+              <p>
+                <span className="font-medium text-foreground">Trigger:</span> {workflow.trigger}
+              </p>
+              <p>
+                <span className="font-medium text-foreground">Success:</span> {workflow.successCriteria}
+              </p>
+              <p>
+                <span className="font-medium text-foreground">Duration:</span> ~
+                {workflow.estimatedDurationMinutes} min
+              </p>
+            </CardContent>
+            <CardFooter>
+              <Button
+                variant={isActive ? "secondary" : "outline"}
+                className="w-full"
+                onClick={() => onSelect(workflow.id)}
+              >
+                {isActive ? "Selected" : "Select workflow"}
+              </Button>
+            </CardFooter>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/agentic-pipelines/src/components/ui/badge.tsx
+++ b/apps/agentic-pipelines/src/components/ui/badge.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  {
+    variants: {
+      variant: {
+        default: "border-transparent bg-primary text-primary-foreground shadow",
+        secondary: "border-transparent bg-secondary text-secondary-foreground",
+        outline: "text-foreground"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/apps/agentic-pipelines/src/components/ui/button.tsx
+++ b/apps/agentic-pipelines/src/components/ui/button.tsx
@@ -1,0 +1,53 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline"
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10"
+      }
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default"
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/apps/agentic-pipelines/src/components/ui/card.tsx
+++ b/apps/agentic-pipelines/src/components/ui/card.tsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-xl border bg-card text-card-foreground shadow",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn("text-2xl font-semibold leading-none", className)} {...props} />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/apps/agentic-pipelines/src/components/ui/input.tsx
+++ b/apps/agentic-pipelines/src/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = "Input";
+
+export { Input };

--- a/apps/agentic-pipelines/src/components/ui/label.tsx
+++ b/apps/agentic-pipelines/src/components/ui/label.tsx
@@ -1,0 +1,21 @@
+import * as LabelPrimitive from "@radix-ui/react-label";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className
+    )}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/apps/agentic-pipelines/src/components/ui/progress.tsx
+++ b/apps/agentic-pipelines/src/components/ui/progress.tsx
@@ -1,0 +1,26 @@
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-3 w-full overflow-hidden rounded-full bg-muted",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-primary transition-all"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress };

--- a/apps/agentic-pipelines/src/components/ui/scroll-area.tsx
+++ b/apps/agentic-pipelines/src/components/ui/scroll-area.tsx
@@ -1,0 +1,44 @@
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+));
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName;
+
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" && "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" && "h-2.5 border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+));
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName;
+
+export { ScrollArea, ScrollBar };

--- a/apps/agentic-pipelines/src/components/ui/separator.tsx
+++ b/apps/agentic-pipelines/src/components/ui/separator.tsx
@@ -1,0 +1,24 @@
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = "horizontal", decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      "shrink-0 bg-border",
+      orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/apps/agentic-pipelines/src/components/ui/tabs.tsx
+++ b/apps/agentic-pipelines/src/components/ui/tabs.tsx
@@ -1,0 +1,53 @@
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import * as React from "react";
+
+import { cn } from "../../lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 rounded-md border border-border bg-card p-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/apps/agentic-pipelines/src/index.css
+++ b/apps/agentic-pipelines/src/index.css
@@ -1,0 +1,60 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 222.2 84% 4.9%;
+    --muted: 210 40% 96.1%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222.2 84% 4.9%;
+    --card: 0 0% 100%;
+    --card-foreground: 222.2 84% 4.9%;
+    --border: 214.3 31.8% 91.4%;
+    --input: 214.3 31.8% 91.4%;
+    --primary: 262.1 83.3% 57.8%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 210 40% 96.1%;
+    --secondary-foreground: 222.2 47.4% 11.2%;
+    --accent: 210 40% 96.1%;
+    --accent-foreground: 222.2 47.4% 11.2%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 262.1 83.3% 57.8%;
+    --radius: 0.75rem;
+  }
+
+  .dark {
+    --background: 224 71% 4%;
+    --foreground: 213 31% 91%;
+    --muted: 223 47% 11%;
+    --muted-foreground: 215.4 16.3% 56.9%;
+    --popover: 224 71% 4%;
+    --popover-foreground: 215 20.2% 65.1%;
+    --card: 224 71% 4%;
+    --card-foreground: 213 31% 91%;
+    --border: 216 34% 17%;
+    --input: 216 34% 17%;
+    --primary: 210 40% 98%;
+    --primary-foreground: 222.2 47.4% 1.2%;
+    --secondary: 222.2 47.4% 11.2%;
+    --secondary-foreground: 210 40% 98%;
+    --accent: 216 34% 17%;
+    --accent-foreground: 210 40% 98%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --ring: 263.4 70% 50.4%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground antialiased;
+    margin: 0;
+    min-height: 100vh;
+  }
+}

--- a/apps/agentic-pipelines/src/lib/utils.ts
+++ b/apps/agentic-pipelines/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/apps/agentic-pipelines/src/main.tsx
+++ b/apps/agentic-pipelines/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/agentic-pipelines/tailwind.config.js
+++ b/apps/agentic-pipelines/tailwind.config.js
@@ -1,0 +1,71 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ["class"],
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px"
+      }
+    },
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)"
+      },
+      keyframes: {
+        "accordion-down": {
+          from: { height: 0 },
+          to: { height: "var(--radix-accordion-content-height)" }
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: 0 }
+        }
+      },
+      animation: {
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out"
+      }
+    }
+  },
+  plugins: [require("tailwindcss-animate")]
+};

--- a/apps/agentic-pipelines/tsconfig.json
+++ b/apps/agentic-pipelines/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vitest/globals", "vite/client"]
+  },
+  "include": ["src"]
+}

--- a/apps/agentic-pipelines/tsconfig.node.json
+++ b/apps/agentic-pipelines/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/agentic-pipelines/vite.config.ts
+++ b/apps/agentic-pipelines/vite.config.ts
@@ -1,0 +1,10 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts"
+  }
+});

--- a/apps/agentic-pipelines/vitest.setup.ts
+++ b/apps/agentic-pipelines/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- add a Vite + React agentic pipeline experience styled with shadcn components for selecting workflows
- simulate pipeline execution with progress tracking, agent rosters, and operational insights
- provide a Vitest suite and flat ESLint configuration for the new application shell

## Testing
- npm run lint *(fails: missing npm dependencies because the registry is unreachable in the execution environment)*
- npm test *(fails: Vitest binary unavailable because dependencies cannot be installed offline)*

------
https://chatgpt.com/codex/tasks/task_e_68fc31aa8254833089fda22ad082e53b